### PR TITLE
Conversation layout CSS

### DIFF
--- a/webclient/css/app.css
+++ b/webclient/css/app.css
@@ -1,0 +1,3 @@
+html, body{
+  height: 100%;
+}

--- a/webclient/css/conversation.css
+++ b/webclient/css/conversation.css
@@ -1,0 +1,22 @@
+.conversation {
+  max-height: 100%;
+  min-height: 100%;
+  padding-bottom: 50px;
+  position: relative;
+}
+
+.viewport {
+  bottom: 50px;
+  overflow-y: auto;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.composer {
+  background-color: #f5f5f5;
+  bottom: 0;
+  /* Set the fixed height of the footer here */
+  height: 50px;
+  position: absolute;
+}

--- a/webclient/css/sticky-footer.css
+++ b/webclient/css/sticky-footer.css
@@ -10,6 +10,7 @@ body {
   /* Margin bottom by footer height */
   margin-bottom: 50px;
 }
+
 .footer {
   position: absolute;
   bottom: 0;

--- a/webclient/index.html
+++ b/webclient/index.html
@@ -63,8 +63,18 @@
       })();
 
       chatApi.onMessageReceived(function(messageText) {
+        // todo: learn why these types of operations are expensive and how to
+        // mitigate those expenses;
         // Add a new message to the list of messages
         $('#messages').append($('<li class="list-group-item">').text(messageText));
+        
+        var $viewport = $('.viewport')[0];
+        var scrollTop = $viewport.scrollTop;
+        var scrollHeight = $viewport.scrollHeight;
+        var viewportHeight = $viewport.clientHeight;
+        if(scrollHeight -  scrollTop - viewportHeight <= 200) {
+          $viewport.scrollTop = scrollHeight;
+        }
       });
 
       // Listener for Send button

--- a/webclient/index.html
+++ b/webclient/index.html
@@ -4,20 +4,26 @@
     <title>Socket.IO chat</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link href="./css/sticky-footer.css" rel="stylesheet">
+    <link href="./css/app.css" rel="stylesheet">
+    <link href="./css/conversation.css" rel="stylesheet">
   </head>
   <body>
-    <ul id="messages" class="list-group"></ul>
-    <footer class="footer">
-      <form action="">
-        <div class="input-group input-group-lg">
-          <input id="m" type="text" class="form-control" autocomplete="off" placeholder="Say something..."/>
-          <span class="input-group-btn">
-            <button class="btn-primary btn-lg">Send</button>
-          </span>
-        </div>
-      </form>
-    </footer>
+    <div class="container conversation">
+      
+      <div class="viewport">
+        <ul id="messages" class="list-group"></ul>
+      </div>
+      <div class="composer">
+        <form class="form-group">
+          <div class="input-group input-group-lg">
+            <input id="message" type="text" class="form-control" autocomplete="off" placeholder="Say something..."/>
+            <span class="input-group-btn">
+              <button class="btn-primary btn-lg">Send</button>
+            </span>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="http://code.jquery.com/jquery-1.11.1.js"></script>
@@ -64,7 +70,7 @@
       // Listener for Send button
       $('form').submit(function(){
         // Selector for the text input box
-        var inputBoxSel = '#m';
+        var inputBoxSel = '#message';
         
         // Text from the input box
         var messageText = $(inputBoxSel).val();


### PR DESCRIPTION
Move the responsibility of laying out the chat composer and history to more generic elements. Not depenedent on HTML or BODY tags. THey are used to simply fill the window like a normal app